### PR TITLE
revert: restore multi-project-workspace/package.json to ^2.7.3

### DIFF
--- a/multi-project-workspace/package.json
+++ b/multi-project-workspace/package.json
@@ -3,6 +3,6 @@
   "version": "0.1.0",
   "private": true,
   "devDependencies": {
-    "momentic": "^2.133.0"
+    "momentic": "^2.7.3"
   }
 }


### PR DESCRIPTION
## Summary
Reverts the `multi-project-workspace/package.json` change from 6ce11bf, which bumped `momentic` from `^2.7.3` to `^2.133.0` and broke the multi-project setup.

Root package.json (`momentic` + `momentic-mobile` bump) is intentionally left as-is.

## Test plan
- [ ] Verify multi-project workspace works after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)