### PR TITLE
revert: revert "chore: bump momentic and momentic-mobile to latest" (#32)

### DIFF
--- a/multi-project-workspace/package.json
+++ b/multi-project-workspace/package.json
@@ -3,6 +3,6 @@
   "version": "0.1.0",
   "private": true,
   "devDependencies": {
-    "momentic": "^2.133.0"
+    "momentic": "^2.7.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "devDependencies": {
-    "momentic": "^2.133.0",
-    "momentic-mobile": "^0.107.0"
+    "momentic": "^2.125.0",
+    "momentic-mobile": "^0.103.0"
   }
 }


### PR DESCRIPTION
## Summary
Full revert of 6ce11bf, which broke CI.

Restores:
- `package.json`: `momentic` → `^2.125.0`, `momentic-mobile` → `^0.103.0`
- `multi-project-workspace/package.json`: `momentic` → `^2.7.3`

Supersedes #34 (which only reverted the workspace package).

🤖 Generated with [Claude Code](https://claude.com/claude-code)